### PR TITLE
makedoc.g: install HTML style files

### DIFF
--- a/makedoc.g
+++ b/makedoc.g
@@ -5,5 +5,6 @@ pkg := "ALCO";
 dir := DirectoriesPackageLibrary(pkg, "doc")[1];
 
 MakeGAPDocDoc(dir, "alco.xml", [], pkg);
+CopyHTMLStyleFiles( "doc" );
 
 QUIT;


### PR DESCRIPTION
Otherwise the HTML manual looks really bad.

Using AutoDoc in `makedoc.g` would automatically take care of this and many other things.