### PR TITLE
PackageInfo.g: fix PackageWWWHome

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
   Date := "04/02/2024", # dd/mm/yyyy format
   License := "GPL-3.0-or-later",
 
-  PackageWWWHome := "https://github.com/BNasmith/alco",
+  PackageWWWHome := "https://bnasmith.github.io/alco/",
 
   SourceRepository := rec(
       Type := "git",


### PR DESCRIPTION
Without this the package can not be ingested into the GAP package distribution, as you derive `PackageInfoURL` from it later on. But `https://github.com/BNasmith/alco/PackageInfo.g` is not a valid URL.