### PR TITLE
CI: run tests with LoadAllPackages, too

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,6 +36,9 @@ jobs:
           GAPBRANCH: ${{ matrix.gap-branch }}
       - uses: gap-actions/build-pkg@v1
       - uses: gap-actions/run-pkg-tests@v2
+      - uses: gap-actions/run-pkg-tests@v2
+        with:
+          load-all: true
       - uses: gap-actions/process-coverage@v2
       - uses: codecov/codecov-action@v3
 


### PR DESCRIPTION
DO NOT MERGE, please.

This is using an experimental version of `gap-actions/run-pkg-tests`, not sure whether it will work as expected.

Ideally this will show the clash with `IsDesign` in the `sonata` package.