### PR TITLE
CI: run package tests also with only needed packages

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,6 +37,9 @@ jobs:
       - uses: gap-actions/run-pkg-tests@v2
         with:
           load-all: true
+      - uses: gap-actions/run-pkg-tests@v2
+        with:
+          only-needed: true
       - uses: gap-actions/process-coverage@v2
       - uses: codecov/codecov-action@v3
 


### PR DESCRIPTION
This runs the package tests a third time. So in total, they are run
1. with default set of GAP packages loaded before ALCO,
2. with only a minimal set of GAP packages loaded before,
3. with all GAP packages loaded.

This should help weed out any remaining issues and also report
on future issues (at least for changes made via pull requests).
