### PR TITLE
Avoid using InstallValue on non-plain objects

### DIFF
--- a/lib/alco.gd
+++ b/lib/alco.gd
@@ -45,8 +45,6 @@ DeclareOperation( "Coefficients", [ IsCanonicalBasisKleinianIntegersRep,
 
 # Quaternion Tools
 
-DeclareGlobalVariable( "QuaternionD4Basis" );
-
 DeclareOperation("IsHurwitzInt", [ IsQuaternion ] );
 
 DeclareGlobalName( "HurwitzIntegers" );
@@ -67,8 +65,6 @@ DeclareGlobalFunction( "GoldenRationalComponent" );
 DeclareGlobalFunction( "GoldenIrrationalComponent" );
 
 DeclareGlobalFunction( "GoldenModSigma" );
-
-DeclareGlobalVariable( "IcosianH4Generators" );
 
 DeclareOperation("IsIcosian", [ IsQuaternion ] );
 
@@ -100,8 +96,6 @@ BindGlobal( "OctonionAlgebraData", NEW_SORTED_CACHE(true) );
 DeclareCategory( "IsOctonionAlgebra", IsOctonionCollection and IsFullSCAlgebra );
 
     DeclareAttribute( "GramMatrix", IsOctonionAlgebra );
-
-DeclareGlobalVariable( "OctonionE8Basis" );
 
 DeclareOperation("IsOctavianInt", [ IsOctonion ] );
 
@@ -277,10 +271,6 @@ DeclareAttribute( "JordanDesignKreinNumbers", IsAssociationSchemeJordanDesign );
 DeclareGlobalFunction( "IsLeechLatticeGramMatrix" );
 
 DeclareGlobalFunction( "IsGossetLatticeGramMatrix" );
-
-DeclareGlobalVariable( "MOGLeechLatticeGeneratorMatrix" );
-
-DeclareGlobalVariable( "MOGLeechLatticeGramMatrix" );
 
 DeclareCategory( "IsOctonionLattice", IsFreeLeftModule );
 

--- a/lib/alco.gi
+++ b/lib/alco.gi
@@ -160,7 +160,7 @@ InstallMethod( Norm,
     quat -> ExtRepOfObj(quat*ComplexConjugate(quat))[1]
     );
 
-InstallValue( QuaternionD4Basis, Basis(QuaternionAlgebra(Rationals), 
+BindGlobal( "QuaternionD4Basis", Basis(QuaternionAlgebra(Rationals),
     List([  [  -1/2,  -1/2,  -1/2,   1/2 ],
             [  -1/2,  -1/2,   1/2,  -1/2 ],
             [  -1/2,   1/2,  -1/2,  -1/2 ],
@@ -244,7 +244,7 @@ InstallGlobalFunction( GoldenModSigma, function(q)
     return Coefficients(Basis(NF(5,[1,4]), [1, (1-Sqrt(5))/2]), q)[1];
 end );
 
-InstallValue( IcosianH4Generators, Basis(QuaternionAlgebra(Field(Sqrt(5))),
+BindGlobal( "IcosianH4Generators", Basis(QuaternionAlgebra(Field(Sqrt(5))),
     List([  [ 0, -1, 0, 0 ], 
             [ 0, -1/2*E(5)^2-1/2*E(5)^3, 1/2, -1/2*E(5)-1/2*E(5)^4 ],
             [ 0, 0, -1, 0 ], 
@@ -414,7 +414,7 @@ InstallMethod( RealPart,
 
 # Octonion arithmetic tools
 
-InstallValue( OctonionE8Basis, Basis(OctonionAlgebra(Rationals),
+BindGlobal( "OctonionE8Basis", Basis(OctonionAlgebra(Rationals),
     List(
         [[ -1/2, 0, 0, 0, 1/2, 1/2, 1/2, 0 ], 
     [ -1/2, -1/2, 0, -1/2, 0, 0, -1/2, 0 ], 
@@ -1801,7 +1801,7 @@ InstallGlobalFunction( IsGossetLatticeGramMatrix, function(G)
     return true;
 end );
 
-InstallValue( MOGLeechLatticeGeneratorMatrix, [
+BindGlobal( "MOGLeechLatticeGeneratorMatrix", [
     [8,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0],
     [4,4,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0],
     [4,0,4,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0],
@@ -1828,7 +1828,7 @@ InstallValue( MOGLeechLatticeGeneratorMatrix, [
    [-3,1,1,1, 1,1,1,1, 1,1,1,1, 1,1,1,1, 1,1,1,1, 1,1,1,1]
     ]);
 
-InstallValue( MOGLeechLatticeGramMatrix, 
+BindGlobal( "MOGLeechLatticeGramMatrix",
     List(MOGLeechLatticeGeneratorMatrix, x -> 
         List(MOGLeechLatticeGeneratorMatrix, y -> 
             x*y/8


### PR DESCRIPTION
The pair `DeclareGlobalVariable` / `InstallValue` in GAP has unfixable design issues and arguably should never have been added in the first place, but that ship has sailed.

The main issue with these functions is with non-plain objects being used as value. In practice that means using values which are plain lists, plain records or string objects is acceptable (though still undesirable). But using a component or positional objects requires a change of the internal representation of the placeholder that e.g. prevents safe use in a multi threaded GAP. Future GAP versions will therefore issues warnings when code uses `InstallValue` to do that.

Luckily in many cases it suffices to use `BindGlobal`, and this is also the case here.